### PR TITLE
Disable internal helper scripts for GPT3

### DIFF
--- a/NVIDIA/benchmarks/gpt3/implementations/b200_n8_preview_nemo/run.sub
+++ b/NVIDIA/benchmarks/gpt3/implementations/b200_n8_preview_nemo/run.sub
@@ -49,7 +49,7 @@ export SHARE_RERUNS=${SHARE_RERUNS:=0}
 : "${NVTX_FLAG:=0}"
 : "${TIME_TAGS:=0}"
 : "${NCCL_TEST:=1}"
-: "${NCCL_LLM_TEST:=1}"
+: "${NCCL_LLM_TEST:=0}"
 : "${NCCL_TEST_SHARP:=}"
 : "${RUN_ONLY_NCCL:=0}"
 : "${SYNTH_DATA:=0}"
@@ -62,7 +62,7 @@ export SHARE_RERUNS=${SHARE_RERUNS:=0}
 : "${GLOBAL_TMP_CHECKPOINTS_DIR:=}"
 : "${SRUN_KILL_ON_BAD_EXIT:=0}"
 : "${DROPCACHE_CMD:="sudo /sbin/sysctl vm.drop_caches=3"}"
-: "${HANG_MONITOR_TIMEOUT:=$([[ "$WALLTIME" -ge 60 ]] && echo 7 || echo 0)}"  # by default turned off for jobs shorter than 1h, otherwise 5 minutes
+: "${HANG_MONITOR_TIMEOUT:=0}"
 : "${ATTEMPT_CUDA_GDB_CORE_DUMP:=1}"
 : "${POSTPROCESS_CUDA_GDB_CORE_DUMP:=1}"  # set to 1 to extract active kernel info from dumps.
 : "${REMOVE_CUDA_GDB_CORE_DUMP:=1}"  # set to 1 to remove coredumps after processing. Will save a lot of disk space. Valid if POSTPROCESS_CUDA_GDB_CORE_DUMP is 1

--- a/NVIDIA/benchmarks/gpt3/implementations/eos-dfw_n1452_ngc24.04_nemo/run.sub
+++ b/NVIDIA/benchmarks/gpt3/implementations/eos-dfw_n1452_ngc24.04_nemo/run.sub
@@ -26,7 +26,7 @@ set -eux
 : "${WALLTIME:=?WALLTIME not set}"
 
 # Vars with defaults
-: "${MLPERF_RULESET:=4.0.0}"
+: "${MLPERF_RULESET:=4.1.0}"
 : "${MLPERF_SYSTEM_NAME:='unknown'}"
 : "${CHECK_COMPLIANCE:=1}"
 : "${SEED_BASE:=${SEED-$RANDOM}}"
@@ -44,7 +44,7 @@ export SHARE_RERUNS=${SHARE_RERUNS:=0}
 : "${NVTX_FLAG:=0}"
 : "${TIME_TAGS:=0}"
 : "${NCCL_TEST:=1}"
-: "${NCCL_LLM_TEST:=1}"
+: "${NCCL_LLM_TEST:=0}"
 : "${NCCL_TEST_SHARP:=}"
 : "${RUN_ONLY_NCCL:=0}"
 : "${SYNTH_DATA:=0}"
@@ -57,7 +57,7 @@ export SHARE_RERUNS=${SHARE_RERUNS:=0}
 : "${GLOBAL_TMP_CHECKPOINTS_DIR:=}"
 : "${SRUN_KILL_ON_BAD_EXIT:=0}"
 : "${DROPCACHE_CMD:="sudo /sbin/sysctl vm.drop_caches=3"}"
-: "${HANG_MONITOR_TIMEOUT:=$([[ "$WALLTIME" -ge 60 ]] && echo 7 || echo 0)}"  # by default turned off for jobs shorter than 1h, otherwise 5 minutes
+: "${HANG_MONITOR_TIMEOUT:=0}"
 : "${ATTEMPT_CUDA_GDB_CORE_DUMP:=1}"
 : "${POSTPROCESS_CUDA_GDB_CORE_DUMP:=1}"  # set to 1 to extract active kernel info from dumps.
 : "${REMOVE_CUDA_GDB_CORE_DUMP:=1}"  # set to 1 to remove coredumps after processing. Will save a lot of disk space. Valid if POSTPROCESS_CUDA_GDB_CORE_DUMP is 1


### PR DESCRIPTION
This PR disables invoking internal helper scripts by default, facilitating reproducibility.